### PR TITLE
Improve Serializer by allow registration by member pointers (wrapped …

### DIFF
--- a/Farquaad/include/Farquaad/Core/ComponentSerializer.h
+++ b/Farquaad/include/Farquaad/Core/ComponentSerializer.h
@@ -1,13 +1,11 @@
 // Copyright 2015 Bablawn3d5
 #pragma once
 
-#include <json/json.h>
 #include <Farquaad/Core/Serializable.hpp>
+#include <json/json.h>
 #include <entityx/entityx.h>
-#include <array>
 #include <string>
 #include <sstream>
-#include <vector>
 
 namespace ex = entityx;
 

--- a/Farquaad/include/Farquaad/Core/JSONSerializedComponents.h
+++ b/Farquaad/include/Farquaad/Core/JSONSerializedComponents.h
@@ -3,27 +3,116 @@
 #pragma once
 
 #include <Farquaad/Core/SeralizeableComponentMap.h>
+#include <Farquaad/Core/JSONSerializedPrimitiveTypes.hpp>
 #include <Farquaad/Components.hpp>
 #include <json/json.h>
+#include <map>
+#include <string>
 
-template<>
-class SerializableHandle<sf::Vector2f> {
+// Base class for Member serialization
+template<typename C>
+class MemberBase {
 public:
-    static const RegisteredSerializableComponent<sf::Vector2f> rootName;
+    virtual ~MemberBase() = default;
 
-    // To be overitten by template specialziations
-    inline sf::Vector2f fromJSON(const Json::Value&) const;
-    inline Json::Value toJSON(const sf::Vector2f& component) const;
+    virtual void fromJSON(const Json::Value&, C&) const = 0;
+    virtual Json::Value toJSON(const C&) const = 0;
+};
+
+// Defines serialization for a particular member
+template<typename V, typename C>
+class Member : public MemberBase<C> {
+public:
+    typedef V C::* Ptr;
+    Ptr memberPtr;
+
+    explicit Member(Ptr memberPtr) : memberPtr(memberPtr) {}
+
+    inline void fromJSON(const Json::Value& v, C& obj) const {
+        (&obj)->*memberPtr = Serializable::fromJSON<V>(v);
+    }
+
+    inline Json::Value toJSON(const C& obj) const {
+        return Serializable::toJSON((V&)((&obj)->*memberPtr));
+    }
+};
+
+template<class C>
+class SerializeFromRegistry {
+public:
+    typedef std::shared_ptr<MemberBase<C>> MemberBasePtr;
+    typedef std::map<std::string, MemberBasePtr> MemberMap;
+
+    explicit SerializeFromRegistry(const MemberMap& map) : members(map) {}
+    virtual ~SerializeFromRegistry() {}
+
+    virtual const MemberMap GenerateMap() = 0;
+
+    template<class K, class V>
+    static bool isRegistered(const std::map<K, V>& map, const std::string& key) {
+        auto it = map.find(key);
+        if ( it != map.end() ) {
+            return 1;
+        }
+        return 0;
+    }
+
+    template<typename V>
+    static inline void AddMember(MemberMap& members,
+                                 std::string name, V C::* memberPtr) {
+        assert(isRegistered(members, name) == false);
+        // Attempt to workaround unique_ptr issue.
+        members.insert(std::make_pair(name,
+                                      MemberBasePtr(new Member<V, C>(memberPtr))));
+    }
+
+    inline C fromJSON(const Json::Value& v) const {
+        C obj;
+        for ( const auto& pair : members ) {
+            const auto& name = pair.first;
+            const auto& memberPtr = pair.second;
+            memberPtr->fromJSON(v[name], obj);
+        }
+        return obj;
+    }
+
+    inline Json::Value toJSON(const C& obj) const {
+        Json::Value v;
+        for ( const auto& pair : members ) {
+            const auto& name = pair.first;
+            const auto& memberPtr = pair.second;
+            v[name] = memberPtr->toJSON(obj);
+        }
+        return v;
+    }
+
+private:
+    MemberMap members;
+};
+
+template<typename T>
+class SerializableHandle<sf::Vector2<T>> {
+public:
+    //explicit no root name.
+
+    inline sf::Vector2<T> fromJSON(const Json::Value&) const;
+    inline Json::Value toJSON(const sf::Vector2<T>& component) const;
 };
 
 template<>
-class SerializableHandle<Body> {
+class SerializableHandle<Body> : public SerializeFromRegistry<Body> {
 public:
     static const RegisteredSerializableComponent<Body> rootName;
-
-    // To be overitten by template specialziations
-    inline Body fromJSON(const Json::Value&) const;
-    inline Json::Value toJSON(const Body& component) const;
+    SerializableHandle() : SerializeFromRegistry<Body>(this->GenerateMap()) {}
+    const SerializeFromRegistry<Body>::MemberMap GenerateMap();
 };
 
-#include <Farquaad/Core/JSONSerializedComponents.hpp>
+template<>
+class SerializableHandle<Stats> : public SerializeFromRegistry<Stats> {
+public:
+    static const RegisteredSerializableComponent<Stats> rootName;
+    SerializableHandle() : SerializeFromRegistry<Stats>(this->GenerateMap()) {}
+    const SerializeFromRegistry<Stats>::MemberMap GenerateMap();
+};
+
+#include <Farquaad/Core/JSONSerializedComponents.hpp> //NOLINT

--- a/Farquaad/include/Farquaad/Core/JSONSerializedComponents.hpp
+++ b/Farquaad/include/Farquaad/Core/JSONSerializedComponents.hpp
@@ -3,13 +3,14 @@
 #include <Farquaad/Core/JSONSerializedComponents.h>
 #include <Farquaad/Core/Serializable.hpp>
 
-const RegisteredSerializableComponent<sf::Vector2f> SerializableHandle<sf::Vector2f>::rootName{ "vector2f" };
-
-inline sf::Vector2f SerializableHandle<sf::Vector2f>::fromJSON(const Json::Value &v) const {
-    return sf::Vector2f(v[0].asFloat(), v[1].asFloat());
+template<typename T>
+inline sf::Vector2<T> SerializableHandle<sf::Vector2<T>>::fromJSON(const Json::Value &v) const {
+    return sf::Vector2<T>(Serializable::fromJSON<T>(v[0]),
+                          Serializable::fromJSON<T>(v[1]));
 }
 
-inline Json::Value SerializableHandle<sf::Vector2f>::toJSON(const sf::Vector2f & component) const {
+template<typename T>
+inline Json::Value SerializableHandle<sf::Vector2<T>>::toJSON(const sf::Vector2<T> & component) const {
     Json::Value v = Json::arrayValue;
     v[0] = component.x;
     v[1] = component.y;
@@ -18,16 +19,20 @@ inline Json::Value SerializableHandle<sf::Vector2f>::toJSON(const sf::Vector2f &
 
 const RegisteredSerializableComponent<Body> SerializableHandle<Body>::rootName{ "body" };
 
-inline Body SerializableHandle<Body>::fromJSON(const Json::Value &v) const {
-    Body b;
-    b.direction = Serializable::fromJSON<sf::Vector2f>(v["direction"]);
-    b.position = Serializable::fromJSON<sf::Vector2f>(v["position"]);
-    return b;
+inline const SerializeFromRegistry<Body>::MemberMap SerializableHandle<Body>::GenerateMap() {
+    SerializeFromRegistry<Body>::MemberMap map;
+    AddMember(map, "direction", &Body::direction);
+    AddMember(map, "position", &Body::position);
+    return map;
 }
 
-inline Json::Value SerializableHandle<Body>::toJSON(const Body & component) const {
-    Json::Value v;
-    v["direction"] = Serializable::toJSON(component.direction);
-    v["position"] = Serializable::toJSON(component.position);
-    return v;
+const RegisteredSerializableComponent<Stats> SerializableHandle<Stats>::rootName{ "stats" };
+
+inline const SerializeFromRegistry<Stats>::MemberMap SerializableHandle<Stats>::GenerateMap() {
+    SerializeFromRegistry<Stats>::MemberMap map;
+    AddMember(map, "curHP", &Stats::currentHp);
+    AddMember(map, "maxHP", &Stats::maxHp);
+    AddMember(map, "speed", &Stats::speed);
+    AddMember(map, "god", &Stats::godmode);
+    return map;
 }

--- a/Farquaad/include/Farquaad/Core/JSONSerializedPrimitiveTypes.hpp
+++ b/Farquaad/include/Farquaad/Core/JSONSerializedPrimitiveTypes.hpp
@@ -1,0 +1,69 @@
+// Copyright 2015 Bablawn3d5
+
+// This file contains SerializableHandle(s) for primitive built in C++ types.
+// if you wish to implement a handle see JSONSerializedComponent.hpp
+
+#pragma once
+
+#include <json/json.h>
+#include <string>
+
+template<>
+class SerializableHandle<bool> {
+public:
+    // explicitly no rootName. Do not use float as root element.
+    // Makes no sense.
+
+    inline bool fromJSON(const Json::Value& v) const {
+        return v.asBool();
+    }
+
+    inline Json::Value toJSON(const bool& primitive) const {
+        return Json::Value(primitive);
+    }
+};
+
+template<>
+class SerializableHandle<float> {
+public:
+    // explicitly no rootName. Do not use float as root element.
+    // Makes no sense.
+
+    inline float fromJSON(const Json::Value& v) const {
+        return v.asFloat();
+    }
+
+    inline Json::Value toJSON(const float& primitive) const {
+        return Json::Value(primitive);
+    }
+};
+
+template<>
+class SerializableHandle<int> {
+public:
+    // explicitly no rootName. Do not use int as root element.
+    // Makes no sense.
+
+    inline int fromJSON(const Json::Value& v) const {
+        return v.asInt();
+    }
+
+    inline Json::Value toJSON(const int& primitive) const {
+        return Json::Value(primitive);
+    }
+};
+
+template<>
+class SerializableHandle<std::string> {
+public:
+    // explicitly no rootName. Do not use string as root element.
+    // Makes no sense.
+
+    inline std::string fromJSON(const Json::Value& v) const {
+        return v.asString();
+    }
+
+    inline Json::Value toJSON(const std::string& primitive) const {
+        return Json::Value(primitive);
+    }
+};

--- a/Farquaad/include/Farquaad/Core/SeralizeableComponentMap.h
+++ b/Farquaad/include/Farquaad/Core/SeralizeableComponentMap.h
@@ -33,8 +33,8 @@ public:
     }
 };
 
-// Class that defines that the class is regsitered to the global ComponentMap
-// this class should always be implmented as a static member of SerializableHandle.
+// Class that defines that the class is registered to the global ComponentMap
+// this class should always be implemented as a static member of SerializableHandle.
 // It can be treated almost as a string.
 template<class T>
 class RegisteredSerializableComponent {
@@ -48,14 +48,19 @@ public:
     operator const std::string&() const { return rootName; }
 };
 
-// Class defintion for SerializableHandle that should be specailized by each
+// Class definition for SerializableHandle that should be specialized by each
 // component.
+//
+// See JSONSerialziedComponents.h for component specializations
+// See JSONSerialiedPrimitiveTypes.hpp for primitive specializations
 template<class T>
 class SerializableHandle {
 public:
     static const RegisteredSerializableComponent<T> rootName;
 
-    // To be overitten by template specialziations
-    T fromJSON(const Json::Value&) const = 0;
-    Json::Value toJSON(const T& component) const = 0;
+    // To be overwritten by template specializations
+    // If you get an error here saying your instantiating a abstract
+    // class. It means you should specailize SerializableHandle<foo> somewhere.
+    virtual T fromJSON(const Json::Value&) const = 0;
+    virtual Json::Value toJSON(const T& component) const = 0;
 };

--- a/Farquaad/src/Core/CMakeLists.txt
+++ b/Farquaad/src/Core/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SRC
 set(INC
     ${INCROOT}/JSONSerializedComponents.h
     ${INCROOT}/JSONSerializedComponents.hpp
+    ${INCROOT}/JSONSerializedPrimitiveTypes.hpp
     ${INCROOT}/ComponentSerializer.h
     ${INCROOT}/Serializable.hpp
     ${INCROOT}/SeralizeableComponentMap.h

--- a/Farquaad/tests/JSONSerializedComponents_test.cpp
+++ b/Farquaad/tests/JSONSerializedComponents_test.cpp
@@ -26,6 +26,19 @@ std::ostream &operator<<(std::ostream &out, const sf::Vector2<T> &v) {
     return out;
 }
 
+bool operator==(const Stats &r, const Stats &l) {
+    return r.currentHp == l.currentHp &&
+        r.maxHp == l.maxHp &&
+        r.speed == l.speed &&
+        r.godmode == l.godmode;
+}
+
+std::ostream &operator<<(std::ostream &out, const Stats &s) {
+    out << "Stats(" << s.currentHp << "/" << s.maxHp << ","
+        << s.speed << "," << s.godmode << "," << ")";
+    return out;
+}
+
 std::ostream &operator<<(std::ostream &out, const Body &b) {
     out << "Body(" << b.direction << ", " << b.position << ")";
     return out;
@@ -39,6 +52,25 @@ std::string toString(const Json::Value &value) {
 // TODO(SMA) : Do we need this?
 struct JSONSerializedFixture {
 };
+
+TEST_CASE_METHOD(JSONSerializedFixture, "TestComponentStats") {
+    Stats s{ 100.999f, 200000.0f, -20000.0f };
+    s.godmode = true;
+    Json::Value v = Serializable::toJSON(s);
+    REQUIRE(v.isObject());
+    REQUIRE(size(v) == 4);
+    REQUIRE(v["curHP"].asFloat() == s.currentHp);
+    REQUIRE(v["maxHP"].asFloat() == s.maxHp);
+    REQUIRE(v["speed"].asFloat() == s.speed);
+    REQUIRE(v["god"].asBool() == s.godmode);
+
+    Stats actual = Serializable::fromJSON<Stats>(v);
+    REQUIRE(v["curHP"].asFloat() == actual.currentHp);
+    REQUIRE(v["maxHP"].asFloat() == actual.maxHp);
+    REQUIRE(v["speed"].asFloat() == actual.speed);
+    REQUIRE(v["god"].asBool() == actual.godmode);
+    REQUIRE(s == actual);
+}
 
 TEST_CASE_METHOD(JSONSerializedFixture, "TestComponentBody") {
     Body b{ 10.0f, 19.99f, -20.0f, 30.2451f };


### PR DESCRIPTION
…by Member<foo>).

Add serializations for Vector2i and friend
Allow magic registration using SerializeFromRegistry.
Add primitive (bool, float, int, string) Serializable Handles.
Spellcheck
